### PR TITLE
Added countryCode string to Address domain class

### DIFF
--- a/grails-app/domain/org/olf/okapi/modules/directory/Address.groovy
+++ b/grails-app/domain/org/olf/okapi/modules/directory/Address.groovy
@@ -9,6 +9,7 @@ class Address  implements MultiTenant<Address>  {
 
   String id
   String addressLabel
+  String countryCode
 
   static hasMany = [
     lines: AddressLine,
@@ -26,6 +27,7 @@ class Address  implements MultiTenant<Address>  {
   static mapping = {
                  id column:'addr_id', generator: 'uuid2', length:36
        addressLabel column:'addr_label'
+        countryCode column: 'addr_country_code'
                tags cascade:'save-update'
               lines cascade:'all-delete-orphan'
   }

--- a/grails-app/domain/org/olf/okapi/modules/directory/Address.groovy
+++ b/grails-app/domain/org/olf/okapi/modules/directory/Address.groovy
@@ -9,6 +9,12 @@ class Address  implements MultiTenant<Address>  {
 
   String id
   String addressLabel
+
+  /*
+   * For the purposes of properly internationalisable addresses, this field should be filled with
+   * ISO 3166-2 standard country codes, such as DEU or GB-ENG.
+   * The AddressLine 'country' would then be filled with 'Deutschland' or 'Germany' depending on sender's locale
+   */
   String countryCode
 
   static hasMany = [

--- a/grails-app/migrations/directory/create-mod-directory.groovy
+++ b/grails-app/migrations/directory/create-mod-directory.groovy
@@ -712,4 +712,10 @@ databaseChangeLog = {
             column(name: "de_published_last_update", type: "BIGINT");
         }
     }
+
+    changeSet(author: "efreestone (manual)", id: "20200514-1440-001") {
+        addColumn(tableName: "address") {
+            column(name: "addr_country_code", type: "VARCHAR(15)");
+        }
+    }
 }


### PR DESCRIPTION
In line with the work happening on editing Addresses of Directory Entries, this PR adds a countryCode field which allows us to store the ISO-3166-2 country code of an address.

This will be used to allow proper internationalisation of addresses to occur at the AddressLine level, where the `country` line might be filled with `"Frankreich"` or `"France"` depending on the sender's locale.